### PR TITLE
start-vswitch.sh: explicity kill testpmd

### DIFF
--- a/start-vswitch.sh
+++ b/start-vswitch.sh
@@ -438,6 +438,8 @@ killall ovsdb-server
 killall ovsdb-server ovs-vswitchd
 echo "stopping vpp"
 killall vpp
+echo "stopping testpmd"
+killall testpmd
 sleep 3
 rm -rf $prefix/var/run/openvswitch/ovs-vswitchd.pid
 rm -rf $prefix/var/run/openvswitch/ovsdb-server.pid


### PR DESCRIPTION
- When using testpmd it was possible to not kill an existing running
  copy of testpmd if it was using different PCI devices